### PR TITLE
Decouples AcceptAndContentTypeMiddleware from ResponseManagerInterface

### DIFF
--- a/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
+++ b/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\ApiHttp\Manager;
+
+use Chubbyphp\ApiHttp\ApiProblem\ClientError\NotAcceptable;
+use Chubbyphp\ApiHttp\ApiProblem\ClientError\UnsupportedMediaType;
+use Chubbyphp\ApiHttp\Middleware\AcceptAndContentTypeMiddlewareResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndContentTypeMiddlewareResponseFactoryInterface
+{
+
+    /**
+     * @var ResponseManagerInterface
+     */
+    private $responseManager;
+
+    public function __construct(ResponseManagerInterface $responseManager)
+    {
+        $this->responseManager = $responseManager;
+    }
+
+    public function createForNotAcceptable(
+        string $accept,
+        array $acceptableMimeTypes,
+        string $mimeType
+    ): ResponseInterface {
+        return $this->responseManager->createFromApiProblem(
+            new NotAcceptable($accept, $acceptableMimeTypes), $mimeType
+        );
+    }
+
+    public function createForUnsupportedMediaType(
+        string $mediaType,
+        array $supportedMediaTypes,
+        string $mimeType
+    ): ResponseInterface {
+        return $this->responseManager->createFromApiProblem(
+            new UnsupportedMediaType($mediaType, $supportedMediaTypes), $mimeType
+        );
+    }
+}

--- a/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
+++ b/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
@@ -24,7 +24,7 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
 
     /**
      * @param string $accept
-     * @param array|string[] $acceptableMimeTypes
+     * @param array<int, string> $acceptableMimeTypes
      * @param string $mimeType
      * @return ResponseInterface
      */

--- a/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
+++ b/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
@@ -41,7 +41,7 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
 
     /**
      * @param string $mediaType
-     * @param array|string[] $supportedMediaTypes
+     * @param array<int, string> $supportedMediaTypes
      * @param string $mimeType
      * @return ResponseInterface
      */

--- a/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
+++ b/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
@@ -22,6 +22,12 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
         $this->responseManager = $responseManager;
     }
 
+    /**
+     * @param string $accept
+     * @param array|string[] $acceptableMimeTypes
+     * @param string $mimeType
+     * @return ResponseInterface
+     */
     public function createForNotAcceptable(
         string $accept,
         array $acceptableMimeTypes,
@@ -33,6 +39,12 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
         );
     }
 
+    /**
+     * @param string $mediaType
+     * @param array|string[] $supportedMediaTypes
+     * @param string $mimeType
+     * @return ResponseInterface
+     */
     public function createForUnsupportedMediaType(
         string $mediaType,
         array $supportedMediaTypes,

--- a/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
+++ b/src/Manager/AcceptAndContentTypeMiddlewareResponseManager.php
@@ -28,7 +28,8 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
         string $mimeType
     ): ResponseInterface {
         return $this->responseManager->createFromApiProblem(
-            new NotAcceptable($accept, $acceptableMimeTypes), $mimeType
+            new NotAcceptable($accept, $acceptableMimeTypes),
+            $mimeType
         );
     }
 
@@ -38,7 +39,8 @@ final class AcceptAndContentTypeMiddlewareResponseManager implements AcceptAndCo
         string $mimeType
     ): ResponseInterface {
         return $this->responseManager->createFromApiProblem(
-            new UnsupportedMediaType($mediaType, $supportedMediaTypes), $mimeType
+            new UnsupportedMediaType($mediaType, $supportedMediaTypes),
+            $mimeType
         );
     }
 }

--- a/src/Manager/ResponseManager.php
+++ b/src/Manager/ResponseManager.php
@@ -5,16 +5,13 @@ declare(strict_types=1);
 namespace Chubbyphp\ApiHttp\Manager;
 
 use Chubbyphp\ApiHttp\ApiProblem\ApiProblemInterface;
-use Chubbyphp\ApiHttp\ApiProblem\ClientError\NotAcceptable;
-use Chubbyphp\ApiHttp\ApiProblem\ClientError\UnsupportedMediaType;
-use Chubbyphp\ApiHttp\Middleware\AcceptAndContentTypeMiddlewareResponseFactoryInterface;
 use Chubbyphp\Deserialization\DeserializerInterface;
 use Chubbyphp\Serialization\Normalizer\NormalizerContextInterface;
 use Chubbyphp\Serialization\SerializerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
-final class ResponseManager implements ResponseManagerInterface, AcceptAndContentTypeMiddlewareResponseFactoryInterface
+final class ResponseManager implements ResponseManagerInterface
 {
     /**
      * @var ResponseFactoryInterface
@@ -104,21 +101,5 @@ final class ResponseManager implements ResponseManagerInterface, AcceptAndConten
     private function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
-    }
-
-    public function createForNotAcceptable(
-        string $accept,
-        array $acceptableMimeTypes,
-        string $mimeType
-    ): ResponseInterface {
-        return $this->createFromApiProblem(new NotAcceptable($accept, $acceptableMimeTypes), $mimeType);
-    }
-
-    public function createForUnsupportedMediaType(
-        string $mediaType,
-        array $supportedMediaTypes,
-        string $mimeType
-    ): ResponseInterface {
-        return $this->createFromApiProblem(new UnsupportedMediaType($mediaType, $supportedMediaTypes), $mimeType);
     }
 }

--- a/src/Manager/ResponseManager.php
+++ b/src/Manager/ResponseManager.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace Chubbyphp\ApiHttp\Manager;
 
 use Chubbyphp\ApiHttp\ApiProblem\ApiProblemInterface;
+use Chubbyphp\ApiHttp\ApiProblem\ClientError\NotAcceptable;
+use Chubbyphp\ApiHttp\ApiProblem\ClientError\UnsupportedMediaType;
+use Chubbyphp\ApiHttp\Middleware\AcceptAndContentTypeMiddlewareResponseFactoryInterface;
 use Chubbyphp\Deserialization\DeserializerInterface;
 use Chubbyphp\Serialization\Normalizer\NormalizerContextInterface;
 use Chubbyphp\Serialization\SerializerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
-final class ResponseManager implements ResponseManagerInterface
+final class ResponseManager implements ResponseManagerInterface, AcceptAndContentTypeMiddlewareResponseFactoryInterface
 {
     /**
      * @var ResponseFactoryInterface
@@ -42,6 +45,10 @@ final class ResponseManager implements ResponseManagerInterface
 
     /**
      * @param object $object
+     * @param string $accept
+     * @param int $status
+     * @param NormalizerContextInterface|null $context
+     * @return ResponseInterface
      */
     public function create(
         $object,
@@ -97,5 +104,21 @@ final class ResponseManager implements ResponseManagerInterface
     private function setSerializer(SerializerInterface $serializer): void
     {
         $this->serializer = $serializer;
+    }
+
+    public function createForNotAcceptable(
+        string $accept,
+        array $acceptableMimeTypes,
+        string $mimeType
+    ): ResponseInterface {
+        return $this->createFromApiProblem(new NotAcceptable($accept, $acceptableMimeTypes), $mimeType);
+    }
+
+    public function createForUnsupportedMediaType(
+        string $mediaType,
+        array $supportedMediaTypes,
+        string $mimeType
+    ): ResponseInterface {
+        return $this->createFromApiProblem(new UnsupportedMediaType($mediaType, $supportedMediaTypes), $mimeType);
     }
 }

--- a/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
+++ b/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
@@ -22,7 +22,7 @@ interface AcceptAndContentTypeMiddlewareResponseFactoryInterface
 
     /**
      * @param string $mediaType
-     * @param array|string[] $supportedMediaTypes
+     * @param array<int, string> $supportedMediaTypes
      * @param string $mimeType
      * @return ResponseInterface
      */

--- a/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
+++ b/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chubbyphp\ApiHttp\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface AcceptAndContentTypeMiddlewareResponseFactoryInterface
+{
+    public function createForNotAcceptable(
+        string $accept,
+        array $acceptableMimeTypes,
+        string $mimeType
+    ): ResponseInterface;
+
+    public function createForUnsupportedMediaType(
+        string $mediaType,
+        array $supportedMediaTypes,
+        string $mimeType
+    ): ResponseInterface;
+}

--- a/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
+++ b/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
@@ -8,12 +8,24 @@ use Psr\Http\Message\ResponseInterface;
 
 interface AcceptAndContentTypeMiddlewareResponseFactoryInterface
 {
+    /**
+     * @param string $accept
+     * @param array|string[] $acceptableMimeTypes
+     * @param string $mimeType
+     * @return ResponseInterface
+     */
     public function createForNotAcceptable(
         string $accept,
         array $acceptableMimeTypes,
         string $mimeType
     ): ResponseInterface;
 
+    /**
+     * @param string $mediaType
+     * @param array|string[] $supportedMediaTypes
+     * @param string $mimeType
+     * @return ResponseInterface
+     */
     public function createForUnsupportedMediaType(
         string $mediaType,
         array $supportedMediaTypes,

--- a/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
+++ b/src/Middleware/AcceptAndContentTypeMiddlewareResponseFactoryInterface.php
@@ -10,7 +10,7 @@ interface AcceptAndContentTypeMiddlewareResponseFactoryInterface
 {
     /**
      * @param string $accept
-     * @param array|string[] $acceptableMimeTypes
+     * @param array<int, string> $acceptableMimeTypes
      * @param string $mimeType
      * @return ResponseInterface
      */

--- a/tests/Unit/Middleware/AcceptAndContentTypeMiddlewareTest.php
+++ b/tests/Unit/Middleware/AcceptAndContentTypeMiddlewareTest.php
@@ -8,6 +8,7 @@ use Chubbyphp\ApiHttp\ApiProblem\ClientError\NotAcceptable;
 use Chubbyphp\ApiHttp\ApiProblem\ClientError\UnsupportedMediaType;
 use Chubbyphp\ApiHttp\Manager\ResponseManagerInterface;
 use Chubbyphp\ApiHttp\Middleware\AcceptAndContentTypeMiddleware;
+use Chubbyphp\ApiHttp\Middleware\AcceptAndContentTypeMiddlewareResponseFactoryInterface;
 use Chubbyphp\Mock\Argument\ArgumentCallback;
 use Chubbyphp\Mock\Call;
 use Chubbyphp\Mock\MockByCallsTrait;
@@ -55,21 +56,14 @@ final class AcceptAndContentTypeMiddlewareTest extends TestCase
         /** @var ContentTypeNegotiatorInterface|MockObject $contentTypeNegotiator */
         $contentTypeNegotiator = $this->getMockByCalls(ContentTypeNegotiatorInterface::class, []);
 
-        /** @var ResponseManagerInterface|MockObject $responseManager */
-        $responseManager = $this->getMockByCalls(ResponseManagerInterface::class, [
-            Call::create('createFromApiProblem')
-                ->with(
-                    new ArgumentCallback(function (NotAcceptable $apiProblem): void {
-                        self::assertSame('application/xml', $apiProblem->getAccept());
-                        self::assertSame(['application/json'], $apiProblem->getAcceptables());
-                    }),
-                    'application/json',
-                    null
-                )
+        /** @var AcceptAndContentTypeMiddlewareResponseFactoryInterface|MockObject $responseFactory */
+        $responseFactory = $this->getMockByCalls(AcceptAndContentTypeMiddlewareResponseFactoryInterface::class, [
+            Call::create('createForNotAcceptable')
+                ->with('application/xml', ['application/json'], 'application/json')
                 ->willReturn($response),
         ]);
 
-        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseManager);
+        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseFactory);
 
         self::assertSame($response, $middleware->process($request, $requestHandler));
     }
@@ -115,10 +109,10 @@ final class AcceptAndContentTypeMiddlewareTest extends TestCase
         /** @var ContentTypeNegotiatorInterface|MockObject $contentTypeNegotiator */
         $contentTypeNegotiator = $this->getMockByCalls(ContentTypeNegotiatorInterface::class, []);
 
-        /** @var ResponseManagerInterface|MockObject $responseManager */
-        $responseManager = $this->getMockByCalls(ResponseManagerInterface::class, []);
+        /** @var AcceptAndContentTypeMiddlewareResponseFactoryInterface|MockObject $responseFactory */
+        $responseFactory = $this->getMockByCalls(AcceptAndContentTypeMiddlewareResponseFactoryInterface::class, []);
 
-        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseManager);
+        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseFactory);
 
         self::assertSame($response, $middleware->process($request, $requestHandler));
     }
@@ -159,21 +153,14 @@ final class AcceptAndContentTypeMiddlewareTest extends TestCase
             Call::create('getSupportedMediaTypes')->with()->willReturn(['application/json']),
         ]);
 
-        /** @var ResponseManagerInterface|MockObject $responseManager */
-        $responseManager = $this->getMockByCalls(ResponseManagerInterface::class, [
-            Call::create('createFromApiProblem')
-                ->with(
-                    new ArgumentCallback(function (UnsupportedMediaType $apiProblem): void {
-                        self::assertSame('application/xml', $apiProblem->getMediaType());
-                        self::assertSame(['application/json'], $apiProblem->getSupportedMediaTypes());
-                    }),
-                    'application/json',
-                    null
-                )
+        /** @var AcceptAndContentTypeMiddlewareResponseFactoryInterface|MockObject $responseFactory */
+        $responseFactory = $this->getMockByCalls(AcceptAndContentTypeMiddlewareResponseFactoryInterface::class, [
+            Call::create('createForUnsupportedMediaType')
+                ->with('application/xml', ['application/json'], 'application/json')
                 ->willReturn($response),
         ]);
 
-        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseManager);
+        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseFactory);
 
         self::assertSame($response, $middleware->process($request, $requestHandler));
     }
@@ -227,10 +214,10 @@ final class AcceptAndContentTypeMiddlewareTest extends TestCase
             Call::create('negotiate')->with($request)->willReturn($contentType),
         ]);
 
-        /** @var ResponseManagerInterface|MockObject $responseManager */
-        $responseManager = $this->getMockByCalls(ResponseManagerInterface::class, []);
+        /** @var AcceptAndContentTypeMiddlewareResponseFactoryInterface|MockObject $responseFactory */
+        $responseFactory = $this->getMockByCalls(AcceptAndContentTypeMiddlewareResponseFactoryInterface::class, []);
 
-        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseManager);
+        $middleware = new AcceptAndContentTypeMiddleware($acceptNegotiator, $contentTypeNegotiator, $responseFactory);
 
         self::assertSame($response, $middleware->process($request, $requestHandler));
     }


### PR DESCRIPTION
This PR decouples `AcceptAndContentTypeMiddleware` from `ResponseManagerInterface` and `ApiProblem`. Therefor it makes it possible to use the `AcceptAndContentTypeMiddleware` as a standalone class without being dependent on the generic `ResponseManagerInterface` that serves many other concerns as well beside generating responses for this middleware and one is not forced to react with `ApiProblem`s as response if something's wrong in the middleware.

**Note:** Some tests for the new classes are missing, naming too long as well for the new classes.

```php
$responseManager = new ResponseManager(...);
$middlewareResponseManager = new AcceptAndContentTypeResponseManager($responseManager);

$middleware = new AcceptAndContentTypeMiddleware(
    $acceptNegotiator,
    $contentTypeNegotiator,
    $middlewareResponseManager
);
```